### PR TITLE
Add flag to stop "venerable" version instead of delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ $ cf zero-downtime-push application-to-replace \
     -p path/to/new/path
 ```
 
+## optional arguments
+The ``--keep-existing-app`` flag will *stop* the existing app instead of deleting it, so that it can be restored more easily.
+
 ## warning
 
 Your application manifest **must** be up to date or the new application that
@@ -51,6 +54,7 @@ delivery environments.
    be load-balanced between the two applications.
 
 3. The old application is deleted along with its route mappings. All traffic
-   now goes to the new application.
+   now goes to the new application. Optionally, the old application can be stopped
+   instead of deleted using the ``--keep-existing-app`` flag.
 
 [indiana-jones]: https://www.youtube.com/watch?v=0gU35Tgtlmg

--- a/autopilot.go
+++ b/autopilot.go
@@ -29,8 +29,21 @@ func venerableAppName(appName string) string {
 	return fmt.Sprintf("%s-venerable", appName)
 }
 
-func getActionsForExistingApp(appRepo *ApplicationRepo, appName, manifestPath, appPath string) []rewind.Action {
+func getActionsForExistingApp(appRepo *ApplicationRepo, appName, manifestPath, appPath string, options AutopilotOptions) []rewind.Action {
 	return []rewind.Action{
+		// delete old version if it still exists
+		{
+			Forward: func() error {
+				appExists, err := appRepo.DoesAppExist(venerableAppName(appName))
+				fatalIf(err)
+				if(appExists) {
+					fmt.Println("Found old version of app running, deleting.")
+					return appRepo.DeleteApplication(venerableAppName(appName))
+				} else {
+					return nil
+				}
+			},
+		},
 		// rename
 		{
 			Forward: func() error {
@@ -50,10 +63,16 @@ func getActionsForExistingApp(appRepo *ApplicationRepo, appName, manifestPath, a
 				return appRepo.RenameApplication(venerableAppName(appName), appName)
 			},
 		},
-		// delete
+		// delete/stop
 		{
 			Forward: func() error {
-				return appRepo.DeleteApplication(venerableAppName(appName))
+				if(options.KeepExisting){
+					fmt.Println("Stopping old version of app. Remove the --keep-existing-app flag to delete it automatically.")
+					return appRepo.StopApplication(venerableAppName(appName))
+				} else {
+					fmt.Println("Deleting old version of app. Use the --keep-existing-app flag to preserve it.")
+					return appRepo.DeleteApplication(venerableAppName(appName))
+				}
 			},
 		},
 	}
@@ -72,7 +91,7 @@ func getActionsForNewApp(appRepo *ApplicationRepo, appName, manifestPath, appPat
 
 func (plugin AutopilotPlugin) Run(cliConnection plugin.CliConnection, args []string) {
 	appRepo := NewApplicationRepo(cliConnection)
-	appName, manifestPath, appPath, err := ParseArgs(args)
+	appName, manifestPath, appPath, options, err := ParseArgs(args)
 	fatalIf(err)
 
 	appExists, err := appRepo.DoesAppExist(appName)
@@ -81,7 +100,7 @@ func (plugin AutopilotPlugin) Run(cliConnection plugin.CliConnection, args []str
 	var actionList []rewind.Action
 
 	if appExists {
-		actionList = getActionsForExistingApp(appRepo, appName, manifestPath, appPath)
+		actionList = getActionsForExistingApp(appRepo, appName, manifestPath, appPath, options)
 	} else {
 		actionList = getActionsForNewApp(appRepo, appName, manifestPath, appPath)
 	}
@@ -96,6 +115,9 @@ func (plugin AutopilotPlugin) Run(cliConnection plugin.CliConnection, args []str
 
 	fmt.Println()
 	fmt.Println("A new version of your application has successfully been pushed!")
+	if(options.KeepExisting){
+		fmt.Println("The old version of your application has not been deleted. It can be restored by invoking cf zero-downtime-revert <appName>")
+	}
 	fmt.Println()
 
 	err = appRepo.ListApplications()
@@ -108,7 +130,7 @@ func (AutopilotPlugin) GetMetadata() plugin.PluginMetadata {
 		Version: plugin.VersionType{
 			Major: 0,
 			Minor: 0,
-			Build: 2,
+			Build: 3,
 		},
 		Commands: []plugin.Command{
 			{
@@ -122,29 +144,36 @@ func (AutopilotPlugin) GetMetadata() plugin.PluginMetadata {
 	}
 }
 
-func ParseArgs(args []string) (string, string, string, error) {
+func ParseArgs(args []string) (string, string, string, AutopilotOptions, error) {
 	flags := flag.NewFlagSet("zero-downtime-push", flag.ContinueOnError)
 	manifestPath := flags.String("f", "", "path to an application manifest")
 	appPath := flags.String("p", "", "path to application files")
+	keepVenerable := flags.Bool("keep-existing-app", false, "keep existing app running")
 
 	err := flags.Parse(args[2:])
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", AutopilotOptions{}, err
 	}
 
 	appName := args[1]
 
 	if *manifestPath == "" {
-		return "", "", "", ErrNoManifest
+		return "", "", "", AutopilotOptions{}, ErrNoManifest
 	}
 
-	return appName, *manifestPath, *appPath, nil
+	options := AutopilotOptions{KeepExisting: *keepVenerable}
+
+	return appName, *manifestPath, *appPath, options, nil
 }
 
 var ErrNoManifest = errors.New("a manifest is required to push this application")
 
 type ApplicationRepo struct {
 	conn plugin.CliConnection
+}
+
+type AutopilotOptions struct {
+	KeepExisting bool
 }
 
 func NewApplicationRepo(conn plugin.CliConnection) *ApplicationRepo {
@@ -171,6 +200,11 @@ func (repo *ApplicationRepo) PushApplication(appName, manifestPath, appPath stri
 
 func (repo *ApplicationRepo) DeleteApplication(appName string) error {
 	_, err := repo.conn.CliCommand("delete", appName, "-f")
+	return err
+}
+
+func (repo *ApplicationRepo) StopApplication(appName string) error {
+	_, err := repo.conn.CliCommand("stop", appName)
 	return err
 }
 


### PR DESCRIPTION
We're leaning towards using the autopilot plugin as a base for our CF app automation, instead of messing with shell scripts that parse the CLI output directly. Hopefully it is of some value to you as well, if you'll forgive my Go training wheels.

Two modifications we require are:
1) Ability to leave old version of app in PCF for revert. That is covered by this change request.
2) Ability to revert to the previous ("venerable") version of the app quickly. That is next.

With this change you can optionally stop the previous version of the app instead of deleting it. I'm working on a "zero-downtime-rollback" command next that will re-instate the venerable as the old version.

I'm using "stop" (and later, "start") to keep the existing app config, as it was at the time the app was pushed, since we no longer have access to the version of the manifest file used to push that app - which may have changed since. I imagine the "zero-downtime-rollback" command will consist of something like:
1) Rename {appName} to {appName}-reverted
2) Rename {appName}-venerable to {appName}
3) Delete {appName}-reverted