### PR TITLE
Updated to ensure that application names are query escaped before usage...

### DIFF
--- a/autopilot.go
+++ b/autopilot.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -185,7 +186,7 @@ func (repo *ApplicationRepo) DoesAppExist(appName string) (bool, error) {
 		return false, err
 	}
 
-	path := fmt.Sprintf(`v2/apps?q=name:%s&q=space_guid:%s`, appName, space.Guid)
+	path := fmt.Sprintf(`v2/apps?q=name:%s&q=space_guid:%s`, url.QueryEscape(appName), space.Guid)
 	result, err := repo.conn.CliCommandWithoutTerminalOutput("curl", path)
 
 	if err != nil {

--- a/autopilot_test.go
+++ b/autopilot_test.go
@@ -144,6 +144,32 @@ var _ = Describe("ApplicationRepo", func() {
 			Expect(result).To(BeTrue())
 		})
 
+		It("URL encodes the application name", func() {
+			response := []string{
+				`{"total_results":1}`,
+			}
+			spaceGUID := "4"
+
+			cliConn.CliCommandWithoutTerminalOutputReturns(response, nil)
+			cliConn.GetCurrentSpaceReturns(
+				plugin_models.Space{
+					SpaceFields: plugin_models.SpaceFields{
+						Guid: spaceGUID,
+					},
+				},
+				nil,
+			)
+
+			result, err := repo.DoesAppExist("app name")
+
+			Expect(cliConn.CliCommandWithoutTerminalOutputCallCount()).To(Equal(1))
+			args := cliConn.CliCommandWithoutTerminalOutputArgsForCall(0)
+			Expect(args).To(Equal([]string{"curl", "v2/apps?q=name:app+name&q=space_guid:4"}))
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+
 		It("returns false if the app does not exist", func() {
 			response := []string{
 				`{"total_results":0}`,


### PR DESCRIPTION
Encountered a case today where we had an existing application whose name had a space in it and autopilot failed with mysterious JSON marshalling error. Updated so that the app name is query escaped before being substituted into the CF API endpoint for retrieving application metadata given that CF allows spaces and other characters in the application name