### PR TITLE
support default manifest path and application name like `cf push` does

### DIFF
--- a/autopilot.go
+++ b/autopilot.go
@@ -134,14 +134,8 @@ func ParseArgs(args []string) (string, string, string, error) {
 
 	appName := args[1]
 
-	if *manifestPath == "" {
-		return "", "", "", ErrNoManifest
-	}
-
 	return appName, *manifestPath, *appPath, nil
 }
-
-var ErrNoManifest = errors.New("a manifest is required to push this application")
 
 type ApplicationRepo struct {
 	conn plugin.CliConnection

--- a/autopilot_test.go
+++ b/autopilot_test.go
@@ -25,14 +25,14 @@ var _ = Describe("Flag Parsing", func() {
 			[]string{
 				"zero-downtime-push",
 				"appname",
-				"-f", "manifest-path",
+				"-f", "./fixtures/manifests/manifest.yml",
 				"-p", "app-path",
 			},
 		)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(appName).To(Equal("appname"))
-		Expect(manifestPath).To(Equal("manifest-path"))
+		Expect(manifestPath).To(Equal("./fixtures/manifests/manifest.yml"))
 		Expect(appPath).To(Equal("app-path"))
 	})
 
@@ -46,6 +46,63 @@ var _ = Describe("Flag Parsing", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(appName).To(Equal("appname"))
+	})
+
+	It("does not require app name if provided in the manifest", func() {
+		appName, manifestPath, _, err := ParseArgs(
+			[]string{
+				"zero-downtime-push",
+				"-f", "./fixtures/manifests/manifest.yml",
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(appName).To(Equal("appname-from-manifest"))
+		Expect(manifestPath).To(Equal("./fixtures/manifests/manifest.yml"))
+	})
+
+	It("errors if no app name is provided (as either a flag or in the manifest)", func() {
+		_, _, _, err := ParseArgs(
+			[]string{
+				"zero-downtime-push",
+				"-f", "./fixtures/manifests/manifest-without-appname.yml",
+			},
+		)
+		Expect(err).To(MatchError(ErrNoAppName))
+	})
+
+	It("the provided app flag takes precedence over an app name in the manifest", func() {
+		appName, manifestPath, _, err := ParseArgs(
+			[]string{
+				"zero-downtime-push",
+				"appname-from-flag",
+				"-f", "./fixtures/manifests/manifest.yml",
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(appName).To(Equal("appname-from-flag"))
+		Expect(manifestPath).To(Equal("./fixtures/manifests/manifest.yml"))
+	})
+
+	It("defaults to finding the name from the first app in the manifest", func() {
+		appName, _, _, _ := ParseArgs(
+			[]string{
+				"zero-downtime-push",
+				"-f", "./fixtures/manifests/manifest-with-multiple-apps.yml",
+			},
+		)
+		Expect(appName).To(Equal("first-appname"))
+	})
+
+	It("errors if manifest path is bad", func() {
+		_, _, _, err := ParseArgs(
+			[]string{
+				"zero-downtime-push",
+				"-f", "./fixtures/manifests/nonexistent-manifest.yml",
+			},
+		)
+		Expect(err).To(HaveOccurred())
 	})
 })
 

--- a/autopilot_test.go
+++ b/autopilot_test.go
@@ -36,15 +36,16 @@ var _ = Describe("Flag Parsing", func() {
 		Expect(appPath).To(Equal("app-path"))
 	})
 
-	It("requires a manifest", func() {
-		_, _, _, err := ParseArgs(
+	It("does not require path or manifest flag", func() {
+		appName, _, _, err := ParseArgs(
 			[]string{
 				"zero-downtime-push",
 				"appname",
-				"-p", "app-path",
 			},
 		)
-		Expect(err).To(MatchError(ErrNoManifest))
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(appName).To(Equal("appname"))
 	})
 })
 

--- a/fixtures/manifests/manifest-with-multiple-apps.yml
+++ b/fixtures/manifests/manifest-with-multiple-apps.yml
@@ -1,0 +1,4 @@
+---
+applications:
+- name: first-appname
+- name: second-appname

--- a/fixtures/manifests/manifest-without-appname.yml
+++ b/fixtures/manifests/manifest-without-appname.yml
@@ -1,0 +1,3 @@
+---
+applications:
+- memory: 256M

--- a/fixtures/manifests/manifest.yml
+++ b/fixtures/manifests/manifest.yml
@@ -1,0 +1,3 @@
+---
+applications:
+- name: appname-from-manifest


### PR DESCRIPTION
We use the autopilot plugin and think it's great, but thought it would be greater if we didn't need to specify the app name or manifest path if:

- it is run from the the app directory
- a manifest.yml with an application with an app name exists.

That way, `cf push` could be swapped out for `zero-downtime-push` with no changes.

We are Pivots from Pivotal Tokyo on the beach and are new to Go, so we may not have written the most idiomatic code. We also used some CF CLI internals; it seemed appropriate but again not quite sure. Happy for any feedback.

Douglas Blumeyer & Robert Gravina