### PR TITLE
Correctly handle the uninstall call from the CLI

### DIFF
--- a/autopilot.go
+++ b/autopilot.go
@@ -72,6 +72,10 @@ func getActionsForNewApp(appRepo *ApplicationRepo, appName, manifestPath, appPat
 }
 
 func (plugin AutopilotPlugin) Run(cliConnection plugin.CliConnection, args []string) {
+	if len(args) > 0 && args[0] == "CLI-MESSAGE-UNINSTALL" {
+		return
+	}
+
 	appRepo := NewApplicationRepo(cliConnection)
 	appName, manifestPath, appPath, err := ParseArgs(args)
 	fatalIf(err)


### PR DESCRIPTION
When you try to uninstall the plugin using `cf uninstall-plugin autopilot`, the CLI calls the plugin with a single argument of `CLI-MESSAGE-UNINSTALL` (see https://github.com/cloudfoundry/cli/tree/master/plugin/plugin_examples#uninstalling-a-plugin).

This PR makes it so that the plugin treats that as a no-op, instead of panicking here: https://github.com/contraband/autopilot/blob/master/autopilot.go#L130