### PR TITLE
Created the keep-old-app flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ $ cf install-plugin path/to/downloaded/binary
 ```
 $ cf zero-downtime-push application-to-replace \
     -f path/to/new_manifest.yml \
-    -p path/to/new/path
+    -p path/to/new/path \
+    [-keep-old-app]
 ```
 
 ## warning

--- a/autopilot_test.go
+++ b/autopilot_test.go
@@ -21,12 +21,13 @@ func TestAutopilot(t *testing.T) {
 
 var _ = Describe("Flag Parsing", func() {
 	It("parses a complete set of args", func() {
-		appName, manifestPath, appPath, showLogs, err := ParseArgs(
+		appName, manifestPath, appPath, showLogs, keepOldApp, err := ParseArgs(
 			[]string{
 				"zero-downtime-push",
 				"appname",
 				"-f", "manifest-path",
 				"-p", "app-path",
+				"-keep-old-app",
 			},
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -35,10 +36,11 @@ var _ = Describe("Flag Parsing", func() {
 		Expect(manifestPath).To(Equal("manifest-path"))
 		Expect(appPath).To(Equal("app-path"))
 		Expect(showLogs).To(Equal(false))
+		Expect(keepOldApp).To(Equal(true))
 	})
 
 	It("requires a manifest", func() {
-		_, _, _, _, err := ParseArgs(
+		_, _, _, _, _, err := ParseArgs(
 			[]string{
 				"zero-downtime-push",
 				"appname",


### PR DESCRIPTION
I have created a new arg flag `keep-old-app`, which skips deleting of the old app. 

This was required by the project which currently work on. 
We use Pivotal Cloud Foundry (PCF) container-to-container networking and Eureka service registry. 

The way we use `autopilot` is the following (let's assume the service we are redeploying is called `test-service`:

- Eureka has our `test-service` already registered 
- we run `zero-downtime-push` with `-keep-old-app`
- `test-service` (the new app) and `test-service-venerable` (the old app) are both running and are both registered in Eureka
- `test-service` is still unavailable because the c2c policies are not set, but because `test-service-venerable` is still running requests are routed to the old service
- we run a script to set up the c2c policies
- requests can now be routed to the old and new app
- we run `cf delete test-service-venerable` to remove the old app
