### PR TITLE
Add rollback only flag

### DIFF
--- a/autopilot.go
+++ b/autopilot.go
@@ -149,6 +149,59 @@ func getActionsForNewApp(appRepo *ApplicationRepo, appName, manifestPath, appPat
 	}
 }
 
+func getRollbackActionsForApp(appRepo *ApplicationRepo, appName string) []rewind.Action {
+	venName := venerableAppName(appName)
+	var err error
+	var curApp, venApp *AppEntity
+
+	return []rewind.Action{
+		// get info about current app
+		{
+			Forward: func() error {
+				curApp, err = appRepo.GetAppMetadata(appName)
+				if err != ErrAppNotFound {
+					return err
+				}
+				curApp = nil
+				return nil
+			},
+		},
+		// get info about ven app
+		{
+			Forward: func() error {
+				venApp, err = appRepo.GetAppMetadata(venName)
+				// Not finding the venerable app is considered an error as it prevents us from rolling back
+				return err
+			},
+		},
+		// start the ven app in case its not running
+		{
+			Forward: func() error {
+				if venApp.State != "STARTED" {
+					return appRepo.StartApplication(venName)
+				}
+				return nil
+			},
+		},
+		// remove the current app such so that next step can rename the venerable
+		{
+			Forward: func() error {
+				// If there is current app remove it so we can rename the venerable
+				if curApp != nil {
+					return appRepo.DeleteApplication(appName)
+				}
+				return nil
+			},
+		},
+		// rename the venerable app making it the current app again
+		{
+			Forward: func() error {
+				return appRepo.RenameApplication(venName, appName)
+			},
+		},
+	}
+}
+
 func (plugin AutopilotPlugin) Run(cliConnection plugin.CliConnection, args []string) {
 	// only handle if actually invoked, else it can't be uninstalled cleanly
 	if args[0] != "zero-downtime-push" {
@@ -156,17 +209,28 @@ func (plugin AutopilotPlugin) Run(cliConnection plugin.CliConnection, args []str
 	}
 
 	appRepo := NewApplicationRepo(cliConnection)
-	appName, manifestPath, appPath, venBehavior, showLogs, err := ParseArgs(args)
+	appName, manifestPath, appPath, venBehavior, showLogs, rollbackOnly, err := ParseArgs(args)
 	fatalIf(err)
 
-	fatalIf((&rewind.Actions{
-		Actions:              getActionsForApp(appRepo, appName, manifestPath, appPath, venBehavior, showLogs),
-		RewindFailureMessage: "Oh no. Something's gone wrong. I've tried to roll back but you should check to see if everything is OK.",
-	}).Execute())
+	if rollbackOnly == false {
+		fatalIf((&rewind.Actions{
+			Actions:              getActionsForApp(appRepo, appName, manifestPath, appPath, venBehavior, showLogs),
+			RewindFailureMessage: "Oh no. Something's gone wrong. I've tried to roll back but you should check to see if everything is OK.",
+		}).Execute())
 
-	fmt.Println()
-	fmt.Println("A new version of your application has successfully been pushed!")
-	fmt.Println()
+		fmt.Println()
+		fmt.Println("A new version of your application has successfully been pushed!")
+		fmt.Println()
+	} else {
+		fatalIf((&rewind.Actions{
+			Actions:              getRollbackActionsForApp(appRepo, appName),
+			RewindFailureMessage: "Oh no. Something's gone wrong. You should check to see if everything is OK.",
+		}).Execute())
+
+		fmt.Println()
+		fmt.Println("The venerable version of your application has successfully been rolled back!")
+		fmt.Println()
+	}
 
 	_ = appRepo.ListApplications()
 }
@@ -184,32 +248,33 @@ func (AutopilotPlugin) GetMetadata() plugin.PluginMetadata {
 				Name:     "zero-downtime-push",
 				HelpText: "Perform a zero-downtime push of an application over the top of an old one",
 				UsageDetails: plugin.Usage{
-					Usage: "$ cf zero-downtime-push application-to-replace \\ \n \t-f path/to/new_manifest.yml \\ \n \t-p path/to/new/path \\ \n \t-b delete|stop|ignore",
+					Usage: "$ cf zero-downtime-push application-to-replace \\ \n \t-f path/to/new_manifest.yml \\ \n \t-p path/to/new/path \\ \n \t-b delete|stop|ignore \\ \n \t[rollback-only]",
 				},
 			},
 		},
 	}
 }
 
-func ParseArgs(args []string) (string, string, string, VenerableBehavior, bool, error) {
+func ParseArgs(args []string) (string, string, string, VenerableBehavior, bool, bool, error) {
 	flags := flag.NewFlagSet("zero-downtime-push", flag.ContinueOnError)
 	manifestPath := flags.String("f", "", "path to an application manifest")
 	appPath := flags.String("p", "", "path to application files")
 	venBehaviorRaw := flags.String("b", "", "behavior regarding venerable application (delete|stop|ignore)")
 	showLogs := flags.Bool("show-app-log", false, "tail and show application log during application start")
+	rollbackOnly := flags.Bool("rollback-only", false, "rollback to the venerable application instead of deploying a new version")
 
 	if len(args) < 2 || strings.HasPrefix(args[1], "-") {
-		return "", "", "", 0, false, ErrNoArgs
+		return "", "", "", 0, false, false, ErrNoArgs
 	}
 	err := flags.Parse(args[2:])
 	if err != nil {
-		return "", "", "", 0, false, err
+		return "", "", "", 0, false, false, err
 	}
 
 	appName := args[1]
 
 	if *manifestPath == "" {
-		return "", "", "", 0, false, ErrNoManifest
+		return "", "", "", 0, false, false, ErrNoManifest
 	}
 
 	//By default delete the venerable application after successful deployment
@@ -221,7 +286,7 @@ func ParseArgs(args []string) (string, string, string, VenerableBehavior, bool, 
 		venBehavior = Ignore
 	}
 
-	return appName, *manifestPath, *appPath, venBehavior, *showLogs, nil
+	return appName, *manifestPath, *appPath, venBehavior, *showLogs, *rollbackOnly, nil
 }
 
 var (
@@ -293,7 +358,7 @@ func (repo *ApplicationRepo) PushApplication(appName, manifestPath, appPath stri
 		}()
 	}
 
-	_, err = repo.conn.CliCommand("start", appName)
+	err = repo.StartApplication(appName)
 	if err != nil {
 		return err
 	}
@@ -308,6 +373,11 @@ func (repo *ApplicationRepo) DeleteApplication(appName string) error {
 
 func (repo *ApplicationRepo) StopApplication(appName string) error {
 	_, err := repo.conn.CliCommand("stop", appName)
+	return err
+}
+
+func (repo *ApplicationRepo) StartApplication(appName string) error {
+	_, err := repo.conn.CliCommand("start", appName)
 	return err
 }
 

--- a/autopilot_test.go
+++ b/autopilot_test.go
@@ -21,7 +21,7 @@ func TestAutopilot(t *testing.T) {
 
 var _ = Describe("Flag Parsing", func() {
 	It("parses a complete set of args", func() {
-		appName, manifestPath, appPath, showLogs, err := ParseArgs(
+		appName, manifestPath, appPath, venBehavior, showLogs, err := ParseArgs(
 			[]string{
 				"zero-downtime-push",
 				"appname",
@@ -34,11 +34,12 @@ var _ = Describe("Flag Parsing", func() {
 		Expect(appName).To(Equal("appname"))
 		Expect(manifestPath).To(Equal("manifest-path"))
 		Expect(appPath).To(Equal("app-path"))
+		Expect(venBehavior).To(Equal(Delete))
 		Expect(showLogs).To(Equal(false))
 	})
 
 	It("requires a manifest", func() {
-		_, _, _, _, err := ParseArgs(
+		_, _, _, _, _, err := ParseArgs(
 			[]string{
 				"zero-downtime-push",
 				"appname",
@@ -219,6 +220,26 @@ var _ = Describe("ApplicationRepo", func() {
 			cliConn.CliCommandReturns([]string{}, errors.New("bad app"))
 
 			err := repo.DeleteApplication("app-name")
+			Expect(err).To(MatchError("bad app"))
+		})
+	})
+
+	Describe("StopApplication", func() {
+		It("stops an application", func() {
+			err := repo.StopApplication("app-name")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(cliConn.CliCommandCallCount()).To(Equal(1))
+			args := cliConn.CliCommandArgsForCall(0)
+			Expect(args).To(Equal([]string{
+				"stop", "app-name",
+			}))
+		})
+
+		It("returns errors from the stop", func() {
+			cliConn.CliCommandReturns([]string{}, errors.New("bad app"))
+
+			err := repo.StopApplication("app-name")
 			Expect(err).To(MatchError("bad app"))
 		})
 	})


### PR DESCRIPTION
Note: This pull request includes #55.

Adds an additional optional flag (_-rollback-only_) to delete the current application and remove the venerable suffix from the venerable application instead of performing a deployment. Is assumes that the venerable application was not deleted after the last successful deployment (using _-b_ _stop_ or _ignore_). The use case is to run more sophisticated integration/end-to-end tests after a successful deployment and have the option to roll back to the previous version if some test case fails.
